### PR TITLE
Fixed logo filter problem

### DIFF
--- a/bash-scripts/m3u8-link-checker
+++ b/bash-scripts/m3u8-link-checker
@@ -35,12 +35,16 @@ printf "%s\n" "Checking $file for working links"
 
 while IFS= read -r line               # while read m3u8 or m3u file check links with ffprobe
 do 
-  link=$(printf "%s\n" "$line" | grep -Eo '(http|https)://[a-zA-Z0-9:0-9./?=_@&%|()[:blank:],;-]*' | grep -v '.[(jpg|png|gif|svg)]$')
+  link=$(printf "%s\n" "$line" | grep -Eo '(http|https)://[a-zA-Z0-9:0-9./?=_@&%|()[:blank:],;-]*' | grep -vP '(http|https|rtmp)://[a-zA-Z0-9:0-9./?=_@&%|()[:blank:],;-]*(jpg|png|gif)')
   [[ $? -eq 0 ]] && ffprobe -hide_banner "$link"
   [[ $? -eq 0 ]] && grep -B 1 "$link" "$file" 2>/dev/null | sed -e '/--/d' >> "$outfile"
 done <"$file"
 
 # check if any working links are found
 [[ -f "$outfile" ]] && sed -i '1i #EXTM3U' "$outfile" || printf "%s\n" "No working links found"
+1)
+
+# uncomment the next line if you want the checked m3u file to overwrite the original (be careful with this)
+# mv $outfile $file
 
 exit "$SUCCESS" # exit 


### PR DESCRIPTION
This fixes the issue where this script won't check any video file which doesn"t have an .m3u8 extension.  Also added an option to overwrite the original m3u.